### PR TITLE
Update example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: JOSM/JOSMPluginAction/workflows/ant.yml@v1
+    uses: JOSM/JOSMPluginAction/.github/workflows/ant.yml@v2
 ```
 
 ## Inputs (all optional)


### PR DESCRIPTION
The current example fails to run with:

> **Invalid workflow file**  
> invalid value workflow reference: references to workflows must be rooted in `.github/workflows`