### PR TITLE
Use actions/checkout v6.

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -50,12 +50,12 @@ on:
         type: string
         default: ${{ github.repository }}
         required: false
-        description: "A variable used for developing the GitHub Action. See actions/checkout@v4."
+        description: "A variable used for developing the GitHub Action. See actions/checkout@v6."
       ref:
         type: string
         default: ''
         required: false
-        description: "A variable used for developing the GitHub Action. See actions/checkout@v4."
+        description: "A variable used for developing the GitHub Action. See actions/checkout@v6."
     outputs:
       tag:
         description: "The release tag"
@@ -90,7 +90,7 @@ jobs:
     outputs:
       revision: ${{ steps.create_revision.outputs.revision }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ inputs.perform-revision-tagging }}
         with:
           fetch-depth: 0

--- a/.github/workflows/internal_ant.yml
+++ b/.github/workflows/internal_ant.yml
@@ -90,7 +90,7 @@ jobs:
     outputs:
       revision: ${{ steps.create_revision.outputs.revision }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: ${{ inputs.perform-revision-tagging }}
         with:
           fetch-depth: 0

--- a/.github/workflows/internal_codeql.yml
+++ b/.github/workflows/internal_codeql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup node
       uses: actions/setup-node@v4
       with:

--- a/actions/plugin_clone/action.yaml
+++ b/actions/plugin_clone/action.yaml
@@ -59,7 +59,7 @@ runs:
     id: josm-plugin-clone
     uses: JOSM/JOSMPluginAction/actions/josm_plugin_clone@v3
 
-  - uses: actions/checkout@v4
+  - uses: actions/checkout@v6
     with:
       path: ${{ steps.josm-plugin-clone.outputs.plugin-dir }}/${{ inputs.plugin-directory }}
       fetch-depth: ${{ inputs.fetch-depth }}


### PR DESCRIPTION
The latest actions/checkout@v6 fix a bug when a tag was pushed. See https://github.com/actions/checkout/issues/1467 